### PR TITLE
Master file path

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3156,7 +3156,7 @@ resolved_reference = "c6373e01e36d49539ea2134f5583fa8d0009a63b"
 
 [[package]]
 name = "mxcubecore"
-version = "1.195.0.8"
+version = "1.195.0.9"
 description = "Core libraries for the MXCuBE application"
 optional = false
 python-versions = ">=3.8,<3.12"
@@ -3200,8 +3200,8 @@ tango = ["PyTango (>=9.3.6,<10.0.0)"]
 [package.source]
 type = "git"
 url = "https://github.com/AustralianSynchrotron/mxcubecore.git"
-reference = "v1.195.0.8"
-resolved_reference = "a15e5835615108aebec468eee13e9552743a8597"
+reference = "v1.195.0.9"
+resolved_reference = "e1fe1ee11f4e7a45c0406a1e0335404bf6ca12db"
 
 [[package]]
 name = "myst-parser"
@@ -6353,4 +6353,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.12"
-content-hash = "307c5bdc820fd69ba2f8c0757398d0e9acdd1f2924efb2d9d0059015b98dfa33"
+content-hash = "dc50a9a9833b6f96cd4267188697b7c2ed1c832456488de06837f8a7b21cff10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubeweb"
-version = "4.238.0.5"
+version = "4.238.0.6"
 license = "LGPL-3.0-or-later"
 description = "MXCuBE Web user interface"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]
@@ -41,7 +41,7 @@ pydantic = ">=2.8.2,<2.11.0"
 PyDispatcher = "^2.0.6"
 pytz = "^2022.6"
 tzlocal = "^4.2"
-mxcubecore =  {git = "https://github.com/AustralianSynchrotron/mxcubecore.git", rev = "v1.195.0.8", extras=["prefect"]}
+mxcubecore =  {git = "https://github.com/AustralianSynchrotron/mxcubecore.git", rev = "v1.195.0.9", extras=["prefect"]}
 bcrypt = "^4.0.1"
 authlib = "^1.3.0"
 

--- a/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
+++ b/ui/src/components/SampleQueue/WorkflowTaskItem.jsx
@@ -246,7 +246,8 @@ export default class WorkflowTaskItem extends Component {
                       alignItems: 'center',
                     }}
                   >
-                    <b>Path:</b>
+                    {/* TODO: Correctly display the path once the sample changer HO has been updated*/}
+                    {/* <b>Path:</b>
                     {this.path(parameters)}
                     <Button
                       variant="outline-secondary"
@@ -261,7 +262,7 @@ export default class WorkflowTaskItem extends Component {
                         className="fa fa-copy"
                         aria-hidden="true"
                       />
-                    </Button>
+                    </Button> */}
                     {/* Collection parameters are shown in MX Prism */}
                     {/* <Button
                       variant="outline-secondary"

--- a/ui/src/components/Tasks/Workflow.jsx
+++ b/ui/src/components/Tasks/Workflow.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { reduxForm, formValueSelector } from 'redux-form';


### PR DESCRIPTION
* When running mxcube sacans, the displayed path is incorrect since the sample name (obtained from the sample changer harfware object) is the barcode (e.g. with the real data the sample path would read something like `HDF5_from_zmq_stream/AX-12345`) 
![mxcube_path](https://github.com/user-attachments/assets/0d7ba91b-bb61-4f99-8f14-ffc892fe230a)

For now, we do not display the path. We'll update this once the sample changer hardware object gets the correct sample name from the data layer api
