### PR TITLE
chore(shapes): do not update screen coord when it gets SET_SHAPES action

### DIFF
--- a/ui/src/reducers/shapes.js
+++ b/ui/src/reducers/shapes.js
@@ -7,7 +7,19 @@ const INITIAL_STATE = {
 function shapesReducer(state = INITIAL_STATE, action = {}) {
   switch (action.type) {
     case 'SET_SHAPES': {
-      return { ...state, shapes: action.shapes };
+      // when grid shapes are updated, do not update screenCoord
+      // as the screenCoord gets weirdly updated by other motors
+      // (e.g., Omega, Y, and so on), but not the X motor.
+      const updatedShapes = { ...action.shapes };
+      Object.keys(updatedShapes).forEach((key) => {
+        // assume we can use label = 'Grid' or t = 'G' according to the payload
+        if (updatedShapes[key].label === 'Grid') {
+          const previousScreenCoord = state.shapes[key].screenCoord;
+          updatedShapes[key].screenCoord = previousScreenCoord;
+        }
+      });
+
+      return { ...state, shapes: updatedShapes };
     }
     case 'ADD_SHAPE': {
       return {


### PR DESCRIPTION
because the screenCoord gets weirdly updated by other motors such as omega, Y and so on, but not the X motor